### PR TITLE
Fix and complete FinBERT finetuning notebook

### DIFF
--- a/FinBERT Finetuning.ipynb
+++ b/FinBERT Finetuning.ipynb
@@ -2,28 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "3daaaa6b",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "import pandas as pd\n",
-    "import torch\n",
-    "from tqdm import tqdm\n",
-    "import numpy as np\n",
-    "\n",
-    "from transformers import (\n",
-    "    BertTokenizer,\n",
-    "    BertForSequenceClassification,\n",
-    ")\n",
-    "\n",
-    "from transformers import BertTokenizer, pipeline\n",
-    "import platform\n",
-    "from tqdm.auto import tqdm\n",
-    "from pathlib import Path"
-   ]
+   "source": "import os\nimport sys\nimport pandas as pd\nimport torch\nimport numpy as np\nfrom tqdm.auto import tqdm\nfrom pathlib import Path\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import accuracy_score, f1_score, classification_report\nfrom torch.optim import AdamW\nfrom transformers import (\n    BertTokenizer,\n    BertForSequenceClassification,\n    get_linear_schedule_with_warmup,\n)\nimport platform"
   },
   {
    "cell_type": "code",
@@ -55,122 +38,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "0afabb14",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "tensor([1.], device='mps:0')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Loading weights: 100%|██████████| 201/201 [00:00<00:00, 40273.97it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "platform.platform()\n",
-    "\n",
-    "torch.backends.mps.is_built()\n",
-    "\n",
-    "if torch.backends.mps.is_available():\n",
-    "    mps_device = torch.device(\"mps\")\n",
-    "    x = torch.ones(1, device=mps_device)\n",
-    "    print(x)\n",
-    "else:\n",
-    "    print(\"MPS device not found.\")\n",
-    "\n",
-    "model = BertForSequenceClassification.from_pretrained(\n",
-    "    \"ZiweiChen/FinBERT-FOMC\", num_labels=3\n",
-    ").to(\"mps\")\n",
-    "\n",
-    "tokenizer = BertTokenizer.from_pretrained(\"ZiweiChen/FinBERT-FOMC\")\n",
-    "\n",
-    "finbert_fomc = pipeline(\n",
-    "    \"text-classification\", model=model, tokenizer=tokenizer, device=\"mps\"\n",
-    ")\n",
-    "\n",
-    "url_map = pd.read_csv(os.path.join(cwd, \"url_map.csv\"))"
-   ]
+   "outputs": [],
+   "source": "platform.platform()\n\nif torch.backends.mps.is_available():\n    device = torch.device(\"mps\")\n    print(f\"Using MPS: {torch.ones(1, device=device)}\")\nelif torch.cuda.is_available():\n    device = torch.device(\"cuda\")\n    print(\"Using CUDA\")\nelse:\n    device = torch.device(\"cpu\")\n    print(\"Using CPU\")\n\n# ignore_mismatched_sizes replaces the 3-class head with a fresh 2-class head\nmodel = BertForSequenceClassification.from_pretrained(\n    \"ZiweiChen/FinBERT-FOMC\", num_labels=2, ignore_mismatched_sizes=True\n).to(device)\n\ntokenizer = BertTokenizer.from_pretrained(\"ZiweiChen/FinBERT-FOMC\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "d6e3804f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "class FinBERTDataset(torch.utils.data.Dataset):\n",
-    "    def __init__(self, dataframe, tokenizer, max_len):\n",
-    "        self.dataframe = dataframe\n",
-    "        self.tokenizer = tokenizer\n",
-    "        self.max_len = max_len\n",
-    "\n",
-    "    def __len__(self):\n",
-    "        return len(self.dataframe)\n",
-    "\n",
-    "    def __getitem__(self, index):\n",
-    "        text = self.dataframe.iloc[index][\"text\"]\n",
-    "        label = self.dataframe.iloc[index][\"label\"]\n",
-    "\n",
-    "        encoding = self.tokenizer.encode_plus(\n",
-    "            text,\n",
-    "            add_special_tokens=True,\n",
-    "            max_length=self.max_len,\n",
-    "            return_token_type_ids=False,\n",
-    "            padding=\"max_length\",\n",
-    "            truncation=True,\n",
-    "            return_attention_mask=True,\n",
-    "            return_tensors=\"pt\",\n",
-    "        )\n",
-    "\n",
-    "        return {\n",
-    "            \"text\": text,\n",
-    "            \"input_ids\": encoding[\"input_ids\"].flatten(),\n",
-    "            \"attention_mask\": encoding[\"attention_mask\"].flatten(),\n",
-    "            \"labels\": torch.tensor(label, dtype=torch.long),\n",
-    "        }"
-   ]
+   "source": "class FinBERTDataset(torch.utils.data.Dataset):\n    def __init__(self, dataframe, tokenizer, max_len):\n        self.dataframe = dataframe.reset_index(drop=True)\n        self.tokenizer = tokenizer\n        self.max_len = max_len\n\n    def __len__(self):\n        return len(self.dataframe)\n\n    def __getitem__(self, index):\n        text = self.dataframe.iloc[index][\"text\"]\n        label = self.dataframe.iloc[index][\"sentiment\"]\n\n        encoding = self.tokenizer.encode_plus(\n            text,\n            add_special_tokens=True,\n            max_length=self.max_len,\n            return_token_type_ids=False,\n            padding=\"max_length\",\n            truncation=True,\n            return_attention_mask=True,\n            return_tensors=\"pt\",\n        )\n\n        return {\n            \"text\": text,\n            \"input_ids\": encoding[\"input_ids\"].flatten(),\n            \"attention_mask\": encoding[\"attention_mask\"].flatten(),\n            \"labels\": torch.tensor(label, dtype=torch.long),\n        }"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "90312c6d",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: '/Users/kylenabors/Documents/GitHub/Central Bank FinBERT Analysis/finbert_model.pt'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[11], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m model \u001b[38;5;241m=\u001b[39m \u001b[43mtorch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfinbert_model.pt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m tokenizer \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mload(os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(cwd, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfinbert_tokenizer.pt\u001b[39m\u001b[38;5;124m\"\u001b[39m))\n\u001b[1;32m      4\u001b[0m dataset \u001b[38;5;241m=\u001b[39m FinBERTDataset(\n\u001b[1;32m      5\u001b[0m     training_data,\n\u001b[1;32m      6\u001b[0m     tokenizer,\n\u001b[1;32m      7\u001b[0m     max_len\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m128\u001b[39m,\n\u001b[1;32m      8\u001b[0m )\n",
-      "File \u001b[0;32m~/Library/Python/3.10/lib/python/site-packages/torch/serialization.py:1530\u001b[0m, in \u001b[0;36mload\u001b[0;34m(f, map_location, pickle_module, weights_only, mmap, **pickle_load_args)\u001b[0m\n\u001b[1;32m   1527\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mencoding\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m pickle_load_args:\n\u001b[1;32m   1528\u001b[0m     pickle_load_args[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mencoding\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mutf-8\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m-> 1530\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43m_open_file_like\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mrb\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m opened_file:\n\u001b[1;32m   1531\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m _is_zipfile(opened_file):\n\u001b[1;32m   1532\u001b[0m         \u001b[38;5;66;03m# The zipfile reader is going to advance the current file position.\u001b[39;00m\n\u001b[1;32m   1533\u001b[0m         \u001b[38;5;66;03m# If we want to actually tail call to torch.jit.load, we need to\u001b[39;00m\n\u001b[1;32m   1534\u001b[0m         \u001b[38;5;66;03m# reset back to the original position.\u001b[39;00m\n\u001b[1;32m   1535\u001b[0m         orig_position \u001b[38;5;241m=\u001b[39m opened_file\u001b[38;5;241m.\u001b[39mtell()\n",
-      "File \u001b[0;32m~/Library/Python/3.10/lib/python/site-packages/torch/serialization.py:795\u001b[0m, in \u001b[0;36m_open_file_like\u001b[0;34m(name_or_buffer, mode)\u001b[0m\n\u001b[1;32m    793\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m_open_file_like\u001b[39m(name_or_buffer: FileLike, mode: \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m _opener[IO[\u001b[38;5;28mbytes\u001b[39m]]:\n\u001b[1;32m    794\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m _is_path(name_or_buffer):\n\u001b[0;32m--> 795\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_open_file\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    796\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    797\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mw\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m mode:\n",
-      "File \u001b[0;32m~/Library/Python/3.10/lib/python/site-packages/torch/serialization.py:776\u001b[0m, in \u001b[0;36m_open_file.__init__\u001b[0;34m(self, name, mode)\u001b[0m\n\u001b[1;32m    775\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, name: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m os\u001b[38;5;241m.\u001b[39mPathLike[\u001b[38;5;28mstr\u001b[39m], mode: \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 776\u001b[0m     \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m)\u001b[49m)\n",
-      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/Users/kylenabors/Documents/GitHub/Central Bank FinBERT Analysis/finbert_model.pt'"
-     ]
-    }
-   ],
-   "source": [
-    "model = torch.load(os.path.join(cwd, \"finbert_model.pt\"))\n",
-    "tokenizer = torch.load(os.path.join(cwd, \"finbert_tokenizer.pt\"))\n",
-    "\n",
-    "dataset = FinBERTDataset(\n",
-    "    training_data,\n",
-    "    tokenizer,\n",
-    "    max_len=128,\n",
-    ")\n",
-    "\n",
-    "dataloader = torch.utils.data.DataLoader(dataset, batch_size=16, shuffle=True)"
-   ]
+   "outputs": [],
+   "source": "RANDOM_SEED = 42\nMAX_LEN = 128\nBATCH_SIZE = 16\nVAL_SIZE = 0.15\n\n# Combine Fed and ECB data; drop Fed-only audience column\nfed = fed_training_data.drop(columns=[\"audience\"], errors=\"ignore\")\ntraining_data = pd.concat([fed, ecb_training_data], ignore_index=True)\n\nprint(f\"Total samples: {len(training_data)}\")\nprint(f\"Label distribution:\\n{training_data['sentiment'].value_counts()}\")\n\ntrain_df, val_df = train_test_split(\n    training_data,\n    test_size=VAL_SIZE,\n    random_state=RANDOM_SEED,\n    stratify=training_data[\"sentiment\"],\n)\nprint(f\"\\nTrain: {len(train_df)}  Val: {len(val_df)}\")\n\ntrain_dataset = FinBERTDataset(train_df, tokenizer, max_len=MAX_LEN)\nval_dataset = FinBERTDataset(val_df, tokenizer, max_len=MAX_LEN)\n\ntrain_loader = torch.utils.data.DataLoader(train_dataset, batch_size=BATCH_SIZE, shuffle=True)\nval_loader = torch.utils.data.DataLoader(val_dataset, batch_size=BATCH_SIZE)"
+  },
+  {
+   "cell_type": "code",
+   "id": "6ad8311b",
+   "source": "EPOCHS = 3\nWARMUP_STEPS = 100\n\noptimizer = AdamW(model.parameters(), lr=2e-5, weight_decay=0.01)\ntotal_steps = len(train_loader) * EPOCHS\nscheduler = get_linear_schedule_with_warmup(\n    optimizer, num_warmup_steps=WARMUP_STEPS, num_training_steps=total_steps\n)\n\n\ndef eval_model(model, loader, device):\n    model.eval()\n    all_preds, all_labels = [], []\n    total_loss = 0\n    with torch.no_grad():\n        for batch in loader:\n            input_ids = batch[\"input_ids\"].to(device)\n            attention_mask = batch[\"attention_mask\"].to(device)\n            labels = batch[\"labels\"].to(device)\n            outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=labels)\n            total_loss += outputs.loss.item()\n            preds = torch.argmax(outputs.logits, dim=1)\n            all_preds.extend(preds.cpu().numpy())\n            all_labels.extend(labels.cpu().numpy())\n    avg_loss = total_loss / len(loader)\n    acc = accuracy_score(all_labels, all_preds)\n    f1 = f1_score(all_labels, all_preds, average=\"weighted\")\n    return avg_loss, acc, f1\n\n\nhistory = []\nfor epoch in range(EPOCHS):\n    model.train()\n    total_train_loss = 0\n    for batch in tqdm(train_loader, desc=f\"Epoch {epoch + 1}/{EPOCHS}\"):\n        optimizer.zero_grad()\n        input_ids = batch[\"input_ids\"].to(device)\n        attention_mask = batch[\"attention_mask\"].to(device)\n        labels = batch[\"labels\"].to(device)\n        outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=labels)\n        loss = outputs.loss\n        total_train_loss += loss.item()\n        loss.backward()\n        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)\n        optimizer.step()\n        scheduler.step()\n\n    avg_train_loss = total_train_loss / len(train_loader)\n    val_loss, val_acc, val_f1 = eval_model(model, val_loader, device)\n    print(\n        f\"Epoch {epoch + 1}: train_loss={avg_train_loss:.4f}  \"\n        f\"val_loss={val_loss:.4f}  val_acc={val_acc:.4f}  val_f1={val_f1:.4f}\"\n    )\n    history.append(\n        {\n            \"epoch\": epoch + 1,\n            \"train_loss\": avg_train_loss,\n            \"val_loss\": val_loss,\n            \"val_acc\": val_acc,\n            \"val_f1\": val_f1,\n        }\n    )\n\nprint(\"\\nTraining complete.\")\nprint(pd.DataFrame(history))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -178,7 +74,7 @@
    "id": "0087fff0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": "# Classification report on validation set\nmodel.eval()\nall_preds, all_labels = [], []\nwith torch.no_grad():\n    for batch in val_loader:\n        input_ids = batch[\"input_ids\"].to(device)\n        attention_mask = batch[\"attention_mask\"].to(device)\n        labels = batch[\"labels\"].to(device)\n        outputs = model(input_ids=input_ids, attention_mask=attention_mask)\n        preds = torch.argmax(outputs.logits, dim=1)\n        all_preds.extend(preds.cpu().numpy())\n        all_labels.extend(labels.cpu().numpy())\n\nprint(classification_report(all_labels, all_preds, target_names=[\"Dovish (0)\", \"Hawkish (1)\"]))\n\n# Save finetuned model using HuggingFace format (preferred over torch.save)\nsave_path = os.path.join(cwd, \"finbert_finetuned\")\nmodel.save_pretrained(save_path)\ntokenizer.save_pretrained(save_path)\nprint(f\"Model saved to: {save_path}\")"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Fixes broken data prep cell — replaces \`torch.load\` of non-existent \`.pt\` files with a stratified 85/15 train/val split combining Fed + ECB labeled data (~9,200 samples)
- Fixes \`FinBERTDataset\` — was reading a \`"label"\` column that doesn't exist; corrected to \`"sentiment"\`
- Fixes model setup — \`num_labels=3→2\` with \`ignore_mismatched_sizes=True\` to replace the 3-class FinBERT-FOMC head with a fresh 2-class head; removes inference pipeline not needed for training
- Adds missing imports — \`sklearn\`, \`AdamW\`, \`get_linear_schedule_with_warmup\`, \`classification_report\`
- Adds training loop — AdamW at lr=2e-5, linear warmup (100 steps), gradient clipping at 1.0, 3 epochs with per-epoch train/val loss, accuracy, and F1
- Adds eval + save cell — full \`classification_report\` on val set, saves via \`save_pretrained\` to \`finbert_finetuned/\`

## Reviewer notes

- Labels are treated as **Dovish (0) / Hawkish (1)** — confirm this matches the labeling convention
- The \`audience\` column from the Fed CSV is dropped before combining with ECB data
- Model is saved in HuggingFace format (\`save_pretrained\`) rather than \`torch.save\`, making it directly reloadable with \`from_pretrained\`